### PR TITLE
fix(users): bio 欄の余白縮小とコピー時の余分な空白を修正

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,10 +11,8 @@
       </h3>
       <p class="text-gray-600 dark:text-gray-200"><%= @user.username %></p>
       <% if @user.bio.present? %>
-        <div class="mt-4 p-4 bg-gray-50 rounded-lg dark:bg-gray-700">
-          <p class="p-3 text-sm text-gray-600 dark:text-gray-300 whitespace-pre-wrap leading-relaxed">
-            <%= @user.bio %>
-          </p>
+        <div class="mt-4 p-3 bg-gray-50 rounded-lg dark:bg-gray-700">
+          <p class="text-sm text-gray-600 dark:text-gray-300 whitespace-pre-wrap leading-relaxed"><%= @user.bio.strip %></p>
         </div>
       <% end %>
 


### PR DESCRIPTION
## Why

プロフィール画面の bio 欄（灰色ボックス）に 2 つの問題があった。

1. **余白が大きすぎる** — `p-4`（外側）+ `p-3`（内側）の二重パディング構造になっており、さらに `whitespace-pre-wrap` によって ERB テンプレートのインデント（改行＋スペース）が描画されることで、体感的な余白がさらに大きく見えていた
2. **不要な空白がコピーされる** — `whitespace-pre-wrap` が有効なため、`<p>` タグ内の ERB インデント（改行＋12スペース）がテキスト選択時にそのままコピー対象に含まれていた

## Summary

- `p-4 + p-3` の二重パディング（計28px）を `p-3`（12px）に統一し、余白を適切に縮小
- `<p>` タグを一行化 + `.strip` を追加し、ERB インデントのコピー混入を修正（bio 本文内の意図的な改行は保持）

## Test plan

- [ ] `bin/rails test` が全て通ること（173件）
- [ ] `/users/@username` でコメント欄の余白が適切に縮小されていること
- [ ] bio テキストを選択・コピーして余分な空白が含まれないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)