### PR TITLE
fix(mailer): correct from address to Resend-authorized domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,13 @@ bin/rails test test/models/user_test.rb:10  # 特定行のテスト実行
 RAILS_ENV=test COVERAGE=1 bin/rails test    # カバレッジ取得（coverage/index.html に出力）
 ```
 
+### バグ修正の方針
+バグ修正の際は TDD の流儀に従うこと：
+1. バグを再現するリグレッションテストを書く
+2. **修正を適用する前に** テストが失敗（red）することを確認
+3. 修正を適用してテストが通る（green）ことを確認
+4. テストと修正を同一コミットに含める
+
 ### Lint とセキュリティチェック
 ```bash
 bin/rubocop           # RuboCop（rubocop-rails-omakase スタイル）

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: "noreply@byrgenwerth.college"
   layout "mailer"
 end

--- a/test/mailers/devise_mailer_test.rb
+++ b/test/mailers/devise_mailer_test.rb
@@ -1,6 +1,20 @@
 require "test_helper"
 
 class DeviseMailerTest < ActionMailer::TestCase
+  test "all devise mails are sent from the authorized domain" do
+    user = users(:willem)
+
+    [
+      Devise::Mailer.confirmation_instructions(user, "token"),
+      Devise::Mailer.reset_password_instructions(user, "token"),
+      Devise::Mailer.password_change(user),
+      Devise::Mailer.email_changed(user)
+    ].each do |mail|
+      assert_equal [ "noreply@byrgenwerth.college" ], mail.from,
+        "#{mail.subject.inspect} must be sent from the Resend-authorized domain"
+    end
+  end
+
   test "confirmation instructions renders styled html email" do
     user = users(:willem)
 


### PR DESCRIPTION
## Summary

- `ApplicationMailer` の `default from:` が Rails 雛形の `from@example.com` のままになっており、Resend API キーの認可ドメインと不一致のため 403 → 500 エラーが発生していた
- `from@example.com` を `noreply@byrgenwerth.college`（`config/initializers/devise.rb` の `mailer_sender` と同じ値）に修正
- 全 4 種の Devise メールの送信元ドメインを検証するリグレッションテストを追加（TDD: red → green 確認済み）

## Root cause

Devise の `config.parent_mailer = "ApplicationMailer"` が設定されているため `DeviseMailer` は `ApplicationMailer` を継承する。`ApplicationMailer` に `default from:` が定義されていると `config.mailer_sender` より優先されることが devise initializer のコメントにも記載されているが、`from@example.com` が残ったままになっていた。

## Test plan

- [x] `bin/rails test test/mailers/devise_mailer_test.rb` — 修正前に 1 failure（red）、修正後に 0 failures（green）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)