### PR TITLE
fix(infra): Dockerfile + initializer の fly deploy ブロッカー修正 (#234)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install application gems
-COPY Gemfile Gemfile.lock ./
+COPY .ruby-version Gemfile Gemfile.lock ./
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
     bundle exec bootsnap precompile --gemfile

--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,1 +1,1 @@
-Resend.api_key = Rails.application.credentials.resend[:api_key] if Rails.env.production?
+Resend.api_key = Rails.application.credentials.resend&.[](:api_key) if Rails.env.production?


### PR DESCRIPTION
## Summary

`fly deploy` を実行した際に発生した 3 つのビルド/起動エラーを修正する。

- **`Dockerfile`**: `bundle install` 前に `.ruby-version` をコピーしていなかったため、Bundler 2.5.22 が `Gemfile` の `ruby file: ".ruby-version"` を読めず `Errno::ENOENT` でクラッシュしていた
- **`config/initializers/resend.rb`**: `assets:precompile` が `RAILS_ENV=production` かつ `RAILS_MASTER_KEY` なし（`SECRET_KEY_BASE_DUMMY=1`）で実行されるため `credentials.resend` が nil になり `NoMethodError` が発生していた → `&.` で guard
- **`app/components/ui/flash_component.rb` / `.html.erb`** (git 変更なし): ファイルパーミッションがローカルで `600` になっており、非 root の `rails` ユーザー (uid 1000) が `require` できず `LoadError` になっていた → `chmod 644` で修正

## Root cause notes

| エラー | 発生フェーズ | 原因 |
|---|---|---|
| `Errno::ENOENT: .ruby-version` | Depot ビルド (bundle install) | Dockerfile の COPY 漏れ |
| `NoMethodError: credentials.resend` | Depot ビルド (assets:precompile) | SECRET_KEY_BASE_DUMMY=1 は secret_key_base のみ bypass |
| `LoadError: flash_component.rb` | fly.io 起動時 (Zeitwerk eager load) | ファイルが `600` で rails user が読めない |

## Test plan

- [x] `docker build` ローカルで成功
- [x] `fly deploy` 成功（`deployment-01KVMCY6QBGN6824ETSFTY7RMK`）
- [x] ヘルスチェック passing（`Health check 'servicecheck-00-http-8080' is now passing`）
- [x] `GET /` → `200 OK` in 78ms（ログ確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)