### PR TITLE
fix(middleware): exclude /up from Basic Auth to fix fly.io health check

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,10 +68,22 @@ Rails.application.configure do
 
   if ENV["MAINTENANCE_AUTH"]
     user, pass = ENV["MAINTENANCE_AUTH"].split(":")
-    config.middleware.use Rack::Auth::Basic, "Maintenance" do |u, p|
-      ActiveSupport::SecurityUtils.secure_compare(u, user) &
-        ActiveSupport::SecurityUtils.secure_compare(p, pass)
-    end
+    config.middleware.use(
+      Class.new do
+        def initialize(app, user, pass)
+          @bypass = app
+          @auth = Rack::Auth::Basic.new(app, "Maintenance") { |u, p|
+            ActiveSupport::SecurityUtils.secure_compare(u, user) &&
+              ActiveSupport::SecurityUtils.secure_compare(p, pass)
+          }
+        end
+
+        def call(env)
+          env["PATH_INFO"] == "/up" ? @bypass.call(env) : @auth.call(env)
+        end
+      end,
+      user, pass
+    )
   end
 
   # Enable DNS rebinding protection and other `Host` header attacks.


### PR DESCRIPTION
## Summary

- `MAINTENANCE_AUTH` env var で有効になる Basic Auth ミドルウェアが `/up` ヘルスチェックもブロックし、fly.io の health check が 401 を受け取って 503 を返していた
- `Rack::Auth::Basic` はパス除外機能を持たないため、無名クラス (`Class.new`) でラップし `PATH_INFO == "/up"` の場合のみ認証をスキップするよう修正

## Test plan

- [x] `curl -v http://localhost:3001/up` → 200（認証なしで通過）
- [x] `curl -v http://localhost:3001/` → 401（認証なしでブロック）
- [x] `curl -v -u admin:test http://localhost:3001/` → 200/302（認証ありで通過）
- [x] `fly deploy` 後 `fly status` で `1 total, 1 passing` を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)