### PR TITLE
feat(design): 案A Refined Slate — UI リデザイン + アクセシビリティ修正

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -3,9 +3,38 @@
 @plugin "@tailwindcss/forms";
 @plugin "@tailwindcss/typography";
 
+@theme {
+  /* surfaces */
+  --color-surface:        #ffffff;
+  --color-surface-subtle: #f8fafc;   /* slate-50  */
+  --color-surface-muted:  #f1f5f9;   /* slate-100 */
+
+  /* borders */
+  --color-border:         #e2e8f0;   /* slate-200 */
+  --color-border-input:   #cbd5e1;   /* slate-300 */
+
+  /* text */
+  --color-text-heading:   #1e293b;   /* slate-800 */
+  --color-text-body:      #334155;   /* slate-700 */
+  --color-text-muted:     #64748b;   /* slate-500 */
+  --color-text-faint:     #94a3b8;   /* slate-400 */
+
+  /* accent / status */
+  --color-accent:         #2563eb;   /* blue-600 */
+  --color-accent-hover:   #3b82f6;   /* blue-500 */
+  --color-ink:            #1e293b;   /* primary button = slate-800 */
+  --color-ink-hover:      #334155;   /* slate-700 */
+  --color-danger:         #dc2626;   /* red-600 */
+  --color-danger-hover:   #ef4444;   /* red-500 */
+
+  /* radius */
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+}
+
 /* preserve the v3 behaviour */
 @layer base {
   *, ::after, ::before, ::backdrop, ::file-selector-button {
-    border-color: var(--color-gray-200, currentColor);
+    border-color: var(--color-slate-200, currentColor);
   }
 }

--- a/app/components/form/checkbox_component.rb
+++ b/app/components/form/checkbox_component.rb
@@ -2,8 +2,8 @@
 
 module Form
   class CheckboxComponent < ApplicationComponent
-    CHECKBOX_CLASSES = "size-4 border rounded-sm dark:bg-gray-800 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3"
-    LABEL_CLASSES = "text-sm text-gray-800 dark:text-gray-200"
+    CHECKBOX_CLASSES = "size-4 border rounded-sm dark:bg-slate-800 dark:border-slate-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3"
+    LABEL_CLASSES = "text-sm text-slate-800 dark:text-slate-200"
     ERROR_CLASSES = "mt-1 text-sm text-red-600 dark:text-red-400"
 
     def initialize(form:, attribute:, label: nil, checked: false, disabled: false, **input_options)

--- a/app/components/form/collection_checkboxes_component.rb
+++ b/app/components/form/collection_checkboxes_component.rb
@@ -2,9 +2,9 @@
 
 module Form
   class CollectionCheckboxesComponent < ApplicationComponent
-    LABEL_CLASSES = "block text-sm text-gray-800 dark:text-gray-200"
-    CHECKBOX_CLASSES = "size-4 border rounded-sm dark:bg-gray-800 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3"
-    CHECKBOX_LABEL_CLASSES = "text-sm text-gray-800 dark:text-gray-200"
+    LABEL_CLASSES = "block text-sm text-slate-800 dark:text-slate-200"
+    CHECKBOX_CLASSES = "size-4 border rounded-sm dark:bg-slate-800 dark:border-slate-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3"
+    CHECKBOX_LABEL_CLASSES = "text-sm text-slate-800 dark:text-slate-200"
 
     def initialize(form:, attribute:, collection:, value_method:, text_method:,
                    label:, checked: nil, disabled: false, **html_options)
@@ -23,7 +23,7 @@ module Form
 
     def checkbox_classes
       if @disabled
-        "size-4 border rounded-sm bg-gray-100 dark:bg-gray-700 dark:border-gray-600 cursor-not-allowed"
+        "size-4 border rounded-sm bg-slate-100 dark:bg-slate-700 dark:border-slate-600 cursor-not-allowed"
       else
         CHECKBOX_CLASSES
       end
@@ -31,7 +31,7 @@ module Form
 
     def checkbox_label_classes
       if @disabled
-        "text-sm text-gray-500 dark:text-gray-400"
+        "text-sm text-slate-500 dark:text-slate-400"
       else
         CHECKBOX_LABEL_CLASSES
       end

--- a/app/components/form/field_component.html.erb
+++ b/app/components/form/field_component.html.erb
@@ -16,7 +16,7 @@
     </span>
   <% end %>
   <% if @hint %>
-    <p class="<%= HINT_CLASSES %>"><%= @hint %></p>
+    <p id="<%= hint_id %>" class="<%= HINT_CLASSES %>"><%= @hint %></p>
   <% end %>
 
   <% if @type == :textarea %>
@@ -28,8 +28,10 @@
   <% end %>
 
   <% if errors? %>
-    <% error_messages.each do |message| %>
-      <p class="<%= ERROR_CLASSES %>"><%= message %></p>
-    <% end %>
+    <div id="<%= error_id %>">
+      <% error_messages.each do |message| %>
+        <p class="<%= ERROR_CLASSES %>"><%= message %></p>
+      <% end %>
+    </div>
   <% end %>
 </div>

--- a/app/components/form/field_component.rb
+++ b/app/components/form/field_component.rb
@@ -2,14 +2,14 @@
 
 module Form
   class FieldComponent < ApplicationComponent
-    INPUT_CLASSES = "block w-full px-4 py-2 mt-2 text-gray-700 bg-white border rounded-lg dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3"
-    LABEL_CLASSES = "block text-sm text-gray-800 dark:text-gray-200"
-    HINT_CLASSES = "text-sm text-gray-600 dark:text-gray-400"
+    INPUT_CLASSES = "block w-full px-4 py-2 mt-2 text-slate-700 bg-white border border-slate-300 rounded-lg dark:bg-slate-800 dark:text-slate-300 dark:border-slate-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3"
+    LABEL_CLASSES = "block text-sm text-slate-800 dark:text-slate-200"
+    HINT_CLASSES = "text-sm text-slate-600 dark:text-slate-400"
     ERROR_CLASSES = "mt-1 text-sm text-red-600 dark:text-red-400"
 
-    TOOLTIP_BUTTON_CLASSES = "text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 focus:outline-hidden"
-    TOOLTIP_BODY_CLASSES = "absolute z-10 bottom-full left-0 mb-2 px-3 py-2 text-sm text-white bg-gray-800 dark:bg-gray-600 rounded-lg w-fit max-w-full opacity-0 invisible transition-opacity duration-200 pointer-events-none"
-    TOOLTIP_ARROW_CLASSES = "absolute top-full border-4 border-transparent border-t-gray-800 dark:border-t-gray-600"
+    TOOLTIP_BUTTON_CLASSES = "text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 focus:outline-hidden"
+    TOOLTIP_BODY_CLASSES = "absolute z-10 bottom-full left-0 mb-2 px-3 py-2 text-sm text-white bg-slate-800 dark:bg-slate-600 rounded-lg w-fit max-w-full opacity-0 invisible transition-opacity duration-200 pointer-events-none"
+    TOOLTIP_ARROW_CLASSES = "absolute top-full border-4 border-transparent border-t-slate-800 dark:border-t-slate-600"
 
     def initialize(form:, attribute:, type: :text, label: nil, required: false, hint: nil, tooltip: nil, **input_options)
       @form = form

--- a/app/components/form/field_component.rb
+++ b/app/components/form/field_component.rb
@@ -47,6 +47,14 @@ module Form
       "tooltip-#{@attribute}"
     end
 
+    def hint_id
+      "hint-#{@attribute}"
+    end
+
+    def error_id
+      "error-#{@attribute}"
+    end
+
     def errors?
       @form.object.errors[@attribute].any?
     end
@@ -69,7 +77,10 @@ module Form
         class: input_classes,
         required: @required
       )
-      opts[:aria] = { describedby: tooltip_id } if tooltip?
+      describedby = [ (tooltip_id if tooltip?), (@hint ? hint_id : nil), (error_id if errors?) ].compact
+      opts[:aria] = {}
+      opts[:aria][:describedby] = describedby.join(" ") if describedby.any?
+      opts[:aria][:invalid] = "true" if errors?
       opts
     end
   end

--- a/app/components/form/layer_field_component.rb
+++ b/app/components/form/layer_field_component.rb
@@ -2,8 +2,8 @@
 
 module Form
   class LayerFieldComponent < ApplicationComponent
-    LABEL_CLASSES = "block text-sm text-gray-800 dark:text-gray-200"
-    INPUT_CLASSES = "block w-full px-4 py-2 mt-2 text-gray-700 bg-white border rounded-lg dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3"
+    LABEL_CLASSES = "block text-sm text-slate-800 dark:text-slate-200"
+    INPUT_CLASSES = "block w-full px-4 py-2 mt-2 text-slate-700 bg-white border border-slate-300 rounded-lg dark:bg-slate-800 dark:text-slate-300 dark:border-slate-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3"
 
     def initialize(form:, **html_options)
       @form = form

--- a/app/components/form/read_only_field_component.rb
+++ b/app/components/form/read_only_field_component.rb
@@ -2,8 +2,8 @@
 
 module Form
   class ReadOnlyFieldComponent < ApplicationComponent
-    LABEL_CLASSES = "block text-sm text-gray-800 dark:text-gray-200"
-    VALUE_CLASSES = "block w-full px-4 py-2 mt-2 text-gray-500 bg-gray-100 rounded-lg dark:bg-gray-700 dark:text-gray-400"
+    LABEL_CLASSES = "block text-sm text-slate-800 dark:text-slate-200"
+    VALUE_CLASSES = "block w-full px-4 py-2 mt-2 text-slate-500 bg-slate-100 rounded-lg dark:bg-slate-700 dark:text-slate-400"
 
     def initialize(form:, attribute:, value:, label: nil, **html_options)
       @form = form

--- a/app/components/form/read_only_field_component.rb
+++ b/app/components/form/read_only_field_component.rb
@@ -3,7 +3,7 @@
 module Form
   class ReadOnlyFieldComponent < ApplicationComponent
     LABEL_CLASSES = "block text-sm text-slate-800 dark:text-slate-200"
-    VALUE_CLASSES = "block w-full px-4 py-2 mt-2 text-slate-500 bg-slate-100 rounded-lg dark:bg-slate-700 dark:text-slate-400"
+    VALUE_CLASSES = "block w-full px-4 py-2 mt-2 text-slate-600 bg-slate-100 rounded-lg dark:bg-slate-700 dark:text-slate-400"
 
     def initialize(form:, attribute:, value:, label: nil, **html_options)
       @form = form

--- a/app/components/form/select_component.rb
+++ b/app/components/form/select_component.rb
@@ -2,8 +2,8 @@
 
 module Form
   class SelectComponent < ApplicationComponent
-    LABEL_CLASSES = "block text-sm font-medium text-gray-800 dark:text-gray-200 mb-2"
-    SELECT_CLASSES = "block w-full px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3"
+    LABEL_CLASSES = "block text-sm font-medium text-slate-800 dark:text-slate-200 mb-2"
+    SELECT_CLASSES = "block w-full px-4 py-2 text-slate-700 bg-white border border-slate-300 rounded-lg dark:bg-slate-800 dark:text-slate-300 dark:border-slate-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3"
 
     def initialize(name:, options:, selected: nil, label: nil, label_id: nil, include_blank: nil, **html_options)
       @name = name

--- a/app/components/ui/alert_component.rb
+++ b/app/components/ui/alert_component.rb
@@ -4,10 +4,10 @@ module Ui
   class AlertComponent < ApplicationComponent
     ICON_PATH = "M20 3.36667C10.8167 3.36667 3.3667 10.8167 3.3667 20C3.3667 29.1833 10.8167 36.6333 20 36.6333C29.1834 36.6333 36.6334 29.1833 36.6334 20C36.6334 10.8167 29.1834 3.36667 20 3.36667ZM19.1334 33.3333V22.9H13.3334L21.6667 6.66667V17.1H27.25L19.1334 33.3333Z"
 
-    BASE_CLASSES = "flex w-full max-w-sm mx-auto overflow-hidden bg-white rounded-lg shadow-md dark:bg-gray-800"
+    BASE_CLASSES = "flex w-full max-w-sm mx-auto overflow-hidden bg-white rounded-lg shadow-md dark:bg-slate-800"
     ICON_WRAPPER_CLASSES = "flex items-center justify-center w-12 bg-red-500"
     TITLE_CLASSES = "font-semibold text-red-500 dark:text-red-400"
-    MESSAGE_CLASSES = "text-sm text-gray-600 dark:text-gray-200"
+    MESSAGE_CLASSES = "text-sm text-slate-600 dark:text-slate-200"
 
     def initialize(resource:, inline_error_attributes: [], **html_options)
       @resource = resource

--- a/app/components/ui/badge_component.rb
+++ b/app/components/ui/badge_component.rb
@@ -3,10 +3,10 @@
 module Ui
   class BadgeComponent < ApplicationComponent
     VARIANT_CLASSES = {
-      default: "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200",
+      default: "bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-200",
       success: "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-200",
-      danger: "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200",
-      warning: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-200"
+      danger:  "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200",
+      warning: "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-200"
     }.freeze
 
     def initialize(variant: :default, **html_options)

--- a/app/components/ui/button_component.rb
+++ b/app/components/ui/button_component.rb
@@ -4,8 +4,8 @@ module Ui
   class ButtonComponent < ApplicationComponent
     VARIANT_CLASSES = {
       primary:   "bg-slate-800 hover:bg-slate-700 text-white focus:ring-blue-300/40",
-      secondary: "bg-blue-600 hover:bg-blue-500 text-white focus:ring-blue-300/40",
-      danger:    "bg-red-600 hover:bg-red-500 text-white focus:ring-blue-300/40",
+      secondary: "bg-blue-600 hover:bg-blue-700 text-white focus:ring-blue-300/40",
+      danger:    "bg-red-600 hover:bg-red-700 text-white focus:ring-blue-300/40",
       outline:   "bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-600 focus:ring-blue-300/40"
     }.freeze
 

--- a/app/components/ui/button_component.rb
+++ b/app/components/ui/button_component.rb
@@ -3,10 +3,10 @@
 module Ui
   class ButtonComponent < ApplicationComponent
     VARIANT_CLASSES = {
-      primary: "bg-gray-800 hover:bg-gray-700 text-white focus:ring-gray-300/50",
-      secondary: "bg-blue-600 hover:bg-blue-500 text-white focus:ring-blue-300/80",
-      danger: "bg-red-600 hover:bg-red-500 text-white focus:ring-red-300/80",
-      outline: "bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 focus:ring-gray-300/50"
+      primary:   "bg-slate-800 hover:bg-slate-700 text-white focus:ring-blue-300/40",
+      secondary: "bg-blue-600 hover:bg-blue-500 text-white focus:ring-blue-300/40",
+      danger:    "bg-red-600 hover:bg-red-500 text-white focus:ring-blue-300/40",
+      outline:   "bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-600 focus:ring-blue-300/40"
     }.freeze
 
     SIZE_CLASSES = {

--- a/app/components/ui/card_component.rb
+++ b/app/components/ui/card_component.rb
@@ -29,7 +29,7 @@ module Ui
     end
 
     def base_classes
-      "w-full bg-white rounded-lg shadow-md dark:bg-gray-800 overflow-hidden"
+      "w-full bg-white rounded-lg shadow-md dark:bg-slate-800 overflow-hidden"
     end
 
     def content_classes

--- a/app/components/ui/description_item_component.rb
+++ b/app/components/ui/description_item_component.rb
@@ -2,8 +2,8 @@
 
 module Ui
   class DescriptionItemComponent < ApplicationComponent
-    LABEL_CLASSES = "text-sm font-medium text-gray-500 dark:text-gray-400"
-    VALUE_CLASSES = "mt-1 text-lg text-gray-700 dark:text-gray-200"
+    LABEL_CLASSES = "text-sm font-medium text-slate-500 dark:text-slate-400"
+    VALUE_CLASSES = "mt-1 text-lg text-slate-700 dark:text-slate-200"
 
     def initialize(label:, value:, **html_options)
       @label = label

--- a/app/components/ui/flash_component.html.erb
+++ b/app/components/ui/flash_component.html.erb
@@ -8,7 +8,7 @@
       <p class="mx-3"><%= @message %></p>
     </div>
 
-    <button class="p-1 transition-colors duration-300 transform rounded-md hover:bg-gray-600/25 focus:outline-hidden"
+    <button class="p-1 transition-colors duration-300 transform rounded-md hover:bg-slate-600/25 focus:outline-hidden"
             data-action="click->flash#delete">
       <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M6 18L18 6M6 6L18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/app/components/ui/flash_component.html.erb
+++ b/app/components/ui/flash_component.html.erb
@@ -8,9 +8,10 @@
       <p class="mx-3"><%= @message %></p>
     </div>
 
-    <button class="p-1 transition-colors duration-300 transform rounded-md hover:bg-slate-600/25 focus:outline-hidden"
+    <button class="p-1 transition-colors duration-300 transform rounded-md hover:bg-slate-600/25 focus:outline-hidden focus:ring-3 focus:ring-blue-300/40"
+            aria-label="閉じる"
             data-action="click->flash#delete">
-      <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         <path d="M6 18L18 6M6 6L18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </button>

--- a/app/components/ui/section_header_component.rb
+++ b/app/components/ui/section_header_component.rb
@@ -2,7 +2,7 @@
 
 module Ui
   class SectionHeaderComponent < ApplicationComponent
-    HEADING_CLASSES = "text-lg font-medium text-gray-800 dark:text-white"
+    HEADING_CLASSES = "text-lg font-medium text-slate-800 dark:text-white"
 
     renders_one :action
 

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,30 @@
-<h2>確認メールを再送信</h2>
+<% provide(:title, "確認メールを再送信") %>
+<%= render Ui::CardComponent.new(size: :sm) do %>
+  <h3 class="mt-3 text-xl font-medium text-center text-slate-800 dark:text-slate-200">
+    確認メールを再送信
+  </h3>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render Ui::AlertComponent.new(resource: resource) %>
+  <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render Ui::AlertComponent.new(resource: resource) %>
 
-  <div class="field">
-    <%= f.label :email, "メールアドレス" %><br>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
-  </div>
+    <%= render Form::FieldComponent.new(
+      form: f,
+      attribute: :email,
+      type: :email,
+      label: "メールアドレス",
+      autofocus: true,
+      autocomplete: "email",
+      wrapper_class: "w-full mt-4"
+    ) %>
 
-  <div class="actions">
-    <%= f.submit "確認メールを再送信" %>
-  </div>
+    <div class="mt-6">
+      <%= render Ui::ButtonComponent.new(variant: :primary, type: :submit, full_width: true) do %>
+        確認メールを再送信
+      <% end %>
+    </div>
+  <% end %>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<div class="mt-4 text-center">
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, t("label.user.password_update")) %>
 <%= render Ui::CardComponent.new(size: :sm) do %>
-  <h3 class="mt-3 text-xl font-medium text-center text-gray-600 dark:text-gray-200">
+  <h3 class="mt-3 text-xl font-medium text-center text-slate-800 dark:text-slate-200">
     <%= t("label.user.password_update") %>
   </h3>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, t("label.user.password_reset")) %>
 <%= render Ui::CardComponent.new(size: :sm) do %>
-  <h3 class="mt-3 text-xl font-medium text-center text-gray-600 dark:text-gray-200">
+  <h3 class="mt-3 text-xl font-medium text-center text-slate-800 dark:text-slate-200">
     <%= t("label.user.password_reset") %>
   </h3>
 
@@ -18,7 +18,7 @@
     ) %>
 
     <div class="mt-6">
-      <%= render Ui::ButtonComponent.new(variant: :primary, type: :submit, full_width: true) do %>
+      <%= render Ui::ButtonComponent.new(variant: :secondary, type: :submit, full_width: true) do %>
         <%= t("label.general.send") %>
       <% end %>
     </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, t("label.user.email_password_update")) %>
 <%= render Ui::CardComponent.new(size: :sm) do %>
-  <h3 class="mt-3 text-xl font-medium text-center text-gray-600 dark:text-gray-200">
+  <h3 class="mt-3 text-xl font-medium text-center text-slate-800 dark:text-slate-200">
     <%= t("label.user.email_password_update") %>
   </h3>
 
@@ -18,20 +18,15 @@
       wrapper_class: "mt-4"
     ) %>
 
-    <%# Password field with multiple hint lines - keeping custom layout %>
-    <div class="mt-4">
-      <%= f.label :password, class: "block text-sm text-gray-800 dark:text-gray-200" %>
-      <% if @minimum_password_length %>
-        <p class="text-sm text-gray-600 dark:text-gray-400">※<%= @minimum_password_length %>文字以上</p>
-      <% end %>
-      <p class="text-sm text-gray-600 dark:text-gray-400">
-        (変更しない場合は空白のままにしてください)
-      </p>
-      <%= f.password_field(:password,
-                           class: "block w-full px-4 py-2 mt-2 text-gray-700 bg-white border rounded-lg dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3",
-                           minlength: @minimum_password_length,
-                           autocomplete: "new-password") %>
-    </div>
+    <%= render Form::FieldComponent.new(
+      form: f,
+      attribute: :password,
+      type: :password,
+      hint: @minimum_password_length ? "※#{@minimum_password_length}文字以上（変更しない場合は空白のままにしてください）" : "（変更しない場合は空白のままにしてください）",
+      minlength: @minimum_password_length,
+      autocomplete: "new-password",
+      wrapper_class: "mt-4"
+    ) %>
 
     <%= render Form::FieldComponent.new(
       form: f,
@@ -46,6 +41,7 @@
       form: f,
       attribute: :current_password,
       type: :password,
+      required: true,
       hint: "(変更するために現在のパスワードが必要です)",
       autocomplete: "current-password",
       wrapper_class: "mt-4"

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, t("label.user.signup")) %>
 <%= render Ui::CardComponent.new(size: :sm) do %>
-  <h3 class="mt-3 text-xl font-medium text-center text-gray-600 dark:text-gray-200">
+  <h3 class="mt-3 text-xl font-medium text-center text-slate-800 dark:text-slate-200">
     <%= t("label.user.signup") %>
   </h3>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,7 +4,7 @@
     <div class="flex items-center justify-center py-4 text-center bg-slate-50 dark:bg-slate-700">
       <span class="text-sm text-slate-600 dark:text-slate-200">アカウント未登録ですか？</span>
       <%= link_to(t("label.user.signup"), new_user_registration_path,
-                  class: "mx-2 text-sm font-bold text-blue-500 dark:text-blue-400 hover:underline") %>
+                  class: "mx-2 text-sm font-bold text-blue-600 dark:text-blue-400 hover:underline") %>
     </div>
   <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,14 +1,14 @@
 <% provide(:title, t("label.user.login")) %>
 <%= render Ui::CardComponent.new(size: :sm) do |card| %>
   <% card.with_footer do %>
-    <div class="flex items-center justify-center py-4 text-center bg-gray-50 dark:bg-gray-700">
-      <span class="text-sm text-gray-600 dark:text-gray-200">アカウント未登録ですか？</span>
+    <div class="flex items-center justify-center py-4 text-center bg-slate-50 dark:bg-slate-700">
+      <span class="text-sm text-slate-600 dark:text-slate-200">アカウント未登録ですか？</span>
       <%= link_to(t("label.user.signup"), new_user_registration_path,
                   class: "mx-2 text-sm font-bold text-blue-500 dark:text-blue-400 hover:underline") %>
     </div>
   <% end %>
 
-  <h3 class="mt-3 text-xl font-medium text-center text-gray-600 dark:text-gray-200">
+  <h3 class="mt-3 text-xl font-medium text-center text-slate-800 dark:text-slate-200">
     <%= t("label.user.login") %>
   </h3>
 
@@ -27,12 +27,12 @@
     <%# Password field with "Forgot password" link - keeping custom layout %>
     <div class="mt-4">
       <div class="flex items-center justify-between">
-        <%= f.label :password, class: "block text-sm text-gray-800 dark:text-gray-200" %>
+        <%= f.label :password, class: "block text-sm text-slate-800 dark:text-slate-200" %>
         <%= link_to("パスワードを忘れた", new_user_password_path,
-                    class: "text-xs text-gray-600 dark:text-gray-400 hover:underline") %>
+                    class: "text-xs text-slate-600 dark:text-slate-400 hover:underline") %>
       </div>
       <%= f.password_field(:password, autofocus: true,
-                           class: "block w-full px-4 py-2 mt-2 text-gray-700 bg-white border rounded-lg dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3",
+                           class: "block w-full px-4 py-2 mt-2 text-slate-700 bg-white border border-slate-300 rounded-lg dark:bg-slate-800 dark:text-slate-300 dark:border-slate-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3",
                            autocomplete: "current-password") %>
     </div>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,32 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br>
-<% end %>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br>
-<% end %>
-
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br>
-<% end %>
-
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br>
-<% end %>
-
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br>
-<% end %>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br>
+<div class="space-y-2 text-sm">
+  <%- if controller_name != 'sessions' %>
+    <%= link_to "ログイン", new_session_path(resource_name),
+                class: "block text-blue-600 hover:underline dark:text-blue-400" %>
   <% end %>
-<% end %>
+
+  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+    <%= link_to "新規登録", new_registration_path(resource_name),
+                class: "block text-blue-600 hover:underline dark:text-blue-400" %>
+  <% end %>
+
+  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+    <%= link_to "パスワードを忘れた場合", new_password_path(resource_name),
+                class: "block text-slate-600 hover:underline dark:text-slate-400" %>
+  <% end %>
+
+  <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+    <%= link_to "確認メールが届いていない場合", new_confirmation_path(resource_name),
+                class: "block text-slate-600 hover:underline dark:text-slate-400" %>
+  <% end %>
+
+  <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+    <%= link_to "アカウントのロック解除メールが届いていない場合", new_unlock_path(resource_name),
+                class: "block text-slate-600 hover:underline dark:text-slate-400" %>
+  <% end %>
+
+  <%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/dungeons/_filter_form.html.erb
+++ b/app/views/dungeons/_filter_form.html.erb
@@ -1,9 +1,9 @@
-<div data-controller="filter" class="mb-6 bg-gray-50 dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700">
+<div data-controller="filter" class="mb-6 bg-slate-50 dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700">
   <%# Collapsible Header %>
   <button type="button"
           data-action="click->filter#toggle"
           data-filter-target="toggleButton"
-          class="w-full px-4 py-3 flex items-center justify-between text-left text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+          class="w-full px-4 py-3 flex items-center justify-between text-left text-slate-800 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 rounded-lg transition-colors"
           aria-expanded="false"
           aria-controls="filter-content">
     <span class="font-medium"><%= t("label.dungeon.filter") %></span>
@@ -44,7 +44,7 @@
 
       <%# Rites Filter (Checkboxes) %>
       <div class="mt-4">
-        <label class="block text-sm font-medium text-gray-800 dark:text-gray-200 mb-2">
+        <label class="block text-sm font-medium text-slate-800 dark:text-slate-200 mb-2">
           <%= t("label.dungeon.attributes.additional_rites") %>
         </label>
         <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
@@ -54,9 +54,9 @@
                                 rite.id,
                                 params.dig(:filter, :rite_ids)&.include?(rite.id.to_s),
                                 id: "rite_#{rite.id}",
-                                class: "size-4 border border-gray-300 rounded dark:bg-gray-800 dark:border-gray-600 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3 text-blue-600" %>
+                                class: "size-4 border border-slate-300 rounded dark:bg-slate-800 dark:border-slate-600 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3 text-blue-600" %>
               <%= label_tag "rite_#{rite.id}", rite.translated_name,
-                            class: "ml-2 text-sm text-gray-800 dark:text-gray-200" %>
+                            class: "ml-2 text-sm text-slate-800 dark:text-slate-200" %>
             </div>
           <% end %>
         </div>
@@ -64,12 +64,16 @@
 
       <%# Action Buttons %>
       <div class="flex flex-wrap gap-3 mt-6">
-        <%= submit_tag t("label.dungeon.search"),
-                       class: "px-6 py-2 font-medium tracking-wide text-white bg-blue-600 rounded-lg hover:bg-blue-500 focus:outline-hidden focus:ring-3 focus:ring-blue-300/80 transition-colors cursor-pointer" %>
-        <%= link_to t("label.dungeon.filter_reset"),
-                    root_path,
-                    data: { turbo_frame: "dungeons-list", action: "click->filter#reset" },
-                    class: "px-6 py-2 font-medium tracking-wide text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-600 dark:hover:bg-gray-700 focus:outline-hidden focus:ring-3 focus:ring-gray-300/50 transition-colors" %>
+        <%= render Ui::ButtonComponent.new(variant: :secondary, type: :submit) do %>
+          <%= t("label.dungeon.search") %>
+        <% end %>
+        <%= render Ui::ButtonComponent.new(
+          variant: :outline,
+          href: root_path,
+          data: { turbo_frame: "dungeons-list", action: "click->filter#reset" }
+        ) do %>
+          <%= t("label.dungeon.filter_reset") %>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/dungeons/_table.html.erb
+++ b/app/views/dungeons/_table.html.erb
@@ -2,42 +2,42 @@
 <div class="flex flex-col">
   <div class="overflow-x-auto">
     <div class="inline-block min-w-full py-2 align-middle">
-      <div class="overflow-hidden border border-gray-200 dark:border-gray-700 rounded-md md:rounded-lg">
+      <div class="overflow-hidden border border-slate-200 dark:border-slate-700 rounded-lg">
         <%# 680px は画面幅 768px (`md` の break point) 時のテーブル幅 %>
-        <table class="min-w-[680px] md:min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-          <thead class="bg-gray-50 dark:bg-gray-800">
+        <table class="min-w-[680px] md:min-w-full divide-y divide-slate-200 dark:divide-slate-700">
+          <thead class="bg-slate-50 dark:bg-slate-800">
           <tr>
-            <th scope="col" class="py-3.5 px-4 text-sm font-normal text-center text-gray-500 dark:text-gray-400">
+            <th scope="col" class="py-3.5 px-4 text-sm font-normal text-center text-slate-500 dark:text-slate-400">
               <%= t("activerecord.attributes.dungeon.glyph") %>
             </th>
-            <th scope="col" class="px-12 py-3.5 text-sm font-normal text-center text-gray-500 dark:text-gray-400">
+            <th scope="col" class="px-12 py-3.5 text-sm font-normal text-center text-slate-500 dark:text-slate-400">
               <%= t("activerecord.attributes.dungeon.area") %>
             </th>
-            <th scope="col" class="px-12 py-3.5 text-sm font-normal text-center text-gray-500 dark:text-gray-400">
+            <th scope="col" class="px-12 py-3.5 text-sm font-normal text-center text-slate-500 dark:text-slate-400">
               <%= t("activerecord.attributes.dungeon.depth") %>
             </th>
-            <th scope="col" class="px-12 py-3.5 text-sm font-normal text-left text-gray-500 dark:text-gray-400">
+            <th scope="col" class="px-12 py-3.5 text-sm font-normal text-left text-slate-500 dark:text-slate-400">
               <%= t("label.dungeon.attributes.additional_rites") %>
             </th>
           </tr>
           </thead>
-          <tbody class="bg-white divide-y divide-gray-200 dark:divide-gray-700 dark:bg-gray-900">
+          <tbody class="bg-white divide-y divide-slate-200 dark:divide-slate-700 dark:bg-slate-900">
           <% dungeons.each do |dungeon| %>
-            <tr>
+            <tr class="hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors">
               <td class="px-4 py-4 text-sm font-medium text-center whitespace-nowrap">
-                <h2 class="font-medium text-gray-800 dark:text-white">
+                <h2 class="font-mono font-semibold text-blue-600 dark:text-blue-400">
                   <%= link_to(dungeon.glyph, dungeon,
                               class: "hover:underline",
                               data: { turbo_frame: "_top" }) %>
                 </h2>
               </td>
               <td class="px-4 py-4 text-sm text-center whitespace-nowrap">
-                <h4 class="text-gray-700 dark:text-gray-200">
+                <h4 class="text-slate-700 dark:text-slate-200">
                   <%= dungeon.translated_area %>
                 </h4>
               </td>
               <td class="px-4 py-4 text-sm text-center whitespace-nowrap">
-                <h4 class="text-gray-700 dark:text-gray-200">
+                <h4 class="font-mono text-slate-700 dark:text-slate-200">
                   <%= dungeon.depth %>
                 </h4>
               </td>

--- a/app/views/dungeons/edit.html.erb
+++ b/app/views/dungeons/edit.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, @dungeon.glyph) %>
 <%= render Ui::CardComponent.new(size: :md) do %>
-  <h3 class="mt-3 text-xl font-medium text-center text-gray-600 dark:text-gray-200">
+  <h3 class="mt-3 text-xl font-medium text-center text-slate-800 dark:text-slate-200">
     <%= t("label.dungeon.edit") %>
   </h3>
 

--- a/app/views/dungeons/new.html.erb
+++ b/app/views/dungeons/new.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, t("label.dungeon.register")) %>
 <%= render Ui::CardComponent.new(size: :md) do %>
-  <h3 class="mt-3 text-xl font-medium text-center text-gray-600 dark:text-gray-200">
+  <h3 class="mt-3 text-xl font-medium text-center text-slate-800 dark:text-slate-200">
     <%= t("label.dungeon.register") %>
   </h3>
 

--- a/app/views/dungeons/show.html.erb
+++ b/app/views/dungeons/show.html.erb
@@ -5,7 +5,7 @@
   <%# Header section %>
   <div class="h-14 flex items-center justify-between">
     <div class="flex">
-      <h3 class="text-2xl font-bold text-gray-600 dark:text-gray-200">
+      <h3 class="text-2xl font-bold font-mono text-slate-800 dark:text-slate-200">
         <%= @dungeon.glyph %>
       </h3>
       <button data-controller="url-copy"
@@ -25,7 +25,7 @@
           <%= t("label.general.update") %>
         <% end %>
         <%= render Ui::ButtonComponent.new(
-          variant: :outline,
+          variant: :danger,
           href: dungeon_path(@dungeon),
           data: { "turbo-method": :delete, turbo_confirm: t("label.general.sure") }
         ) do %>
@@ -47,7 +47,7 @@
 
   <%# Additional Rites section %>
   <div class="mt-6">
-    <p class="text-sm font-medium text-gray-500 dark:text-gray-400">
+    <p class="text-sm font-medium text-slate-500 dark:text-slate-400">
       <%= t("label.dungeon.attributes.additional_rites") %>
     </p>
     <div class="mt-2 flex flex-wrap gap-2">
@@ -62,14 +62,14 @@
   <%# Layers section %>
   <div class="mt-6">
     <%# TODO: I18n %>
-    <p class="text-sm font-medium text-gray-500 dark:text-gray-400">各層</p>
+    <p class="text-sm font-medium text-slate-500 dark:text-slate-400">各層</p>
     <div class="mt-2 space-y-3">
       <% @dungeon.layers.order(:level).each do |layer| %>
-        <div class="p-3 bg-gray-50 rounded-lg dark:bg-gray-700">
-          <p class="text-sm font-medium text-gray-700 dark:text-gray-200">
+        <div class="p-3 bg-slate-50 rounded-lg dark:bg-slate-700">
+          <p class="text-sm font-mono font-medium text-slate-700 dark:text-slate-200">
             <%= t("label.dungeon.attributes.boss_name", level: layer.level) %>
           </p>
-          <p class="mt-1 text-gray-600 dark:text-gray-300">
+          <p class="mt-1 text-slate-600 dark:text-slate-300">
             <%= layer.boss_name.presence || "?" %>
           </p>
         </div>
@@ -85,7 +85,7 @@
           <%= @dungeon.is_open? ? t("label.dungeon.value.open") : t("label.dungeon.value.close") %>
         <% end %>
       </div>
-      <p class="ml-4 text-sm text-gray-500 dark:text-gray-400">
+      <p class="ml-4 text-sm text-slate-500 dark:text-slate-400">
         &laquo;
         <%= link_to @dungeon.user.username,
                     user_path(@dungeon.user),
@@ -98,11 +98,11 @@
 
     <% if @dungeon.comment.present? %>
       <div class="mt-4">
-        <p class="text-sm font-medium text-gray-500 dark:text-gray-400">
+        <p class="text-sm font-medium text-slate-500 dark:text-slate-400">
           <%= t("activerecord.attributes.dungeon.comment") %>
         </p>
-        <div class="mt-2 p-4 bg-gray-50 rounded-lg dark:bg-gray-700">
-          <p class="p-3 text-gray-600 dark:text-gray-300 whitespace-pre-wrap leading-relaxed"><%= @dungeon.comment %></p>
+        <div class="mt-2 p-4 bg-slate-50 rounded-lg dark:bg-slate-700">
+          <p class="p-3 text-slate-600 dark:text-slate-300 whitespace-pre-wrap leading-relaxed"><%= @dungeon.comment %></p>
         </div>
       </div>
     <% end %>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -5,5 +5,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<%= link_to("...", "#",
-            class: "px-2 py-1 text-sm text-slate-500 rounded-md dark:hover:bg-slate-800 dark:text-slate-300 hover:bg-slate-100") %>
+<span class="px-2 py-1 text-sm text-slate-500 dark:text-slate-300">...</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -6,4 +6,4 @@
     remote:        data-remote
 -%>
 <%= link_to("...", "#",
-            class: "px-2 py-1 text-sm text-gray-500 rounded-md dark:hover:bg-gray-800 dark:text-gray-300 hover:bg-gray-100") %>
+            class: "px-2 py-1 text-sm text-slate-500 rounded-md dark:hover:bg-slate-800 dark:text-slate-300 hover:bg-slate-100") %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -8,16 +8,16 @@
 -%>
 <%# TODO: Refactor this code %>
 <% if current_page.last? %>
-  <%= link_to("#",
-              class: "flex items-center px-5 py-2 text-sm text-slate-700 capitalize transition-colors duration-200 bg-white border rounded-md gap-x-2 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-800") do %>
-    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+  <span aria-disabled="true" class="flex items-center px-5 py-2 text-sm text-slate-400 capitalize bg-white border rounded-md gap-x-2 dark:bg-slate-900 dark:text-slate-600 dark:border-slate-700 cursor-not-allowed">
+    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
       <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
     </svg>
-  <% end %>
+    <span class="sr-only">次のページ（無効）</span>
+  </span>
 <% else %>
-  <%= link_to(url, rel: "next", remote: remote,
+  <%= link_to(url, rel: "next", remote: remote, aria: { label: "次のページ" },
               class: "flex items-center px-5 py-2 text-sm text-slate-700 capitalize transition-colors duration-200 bg-white border rounded-md gap-x-2 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-800") do %>
-    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
       <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
     </svg>
   <% end %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -9,14 +9,14 @@
 <%# TODO: Refactor this code %>
 <% if current_page.last? %>
   <%= link_to("#",
-              class: "flex items-center px-5 py-2 text-sm text-gray-700 capitalize transition-colors duration-200 bg-white border rounded-md gap-x-2 hover:bg-gray-100 dark:bg-gray-900 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800") do %>
+              class: "flex items-center px-5 py-2 text-sm text-slate-700 capitalize transition-colors duration-200 bg-white border rounded-md gap-x-2 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-800") do %>
     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
     </svg>
   <% end %>
 <% else %>
   <%= link_to(url, rel: "next", remote: remote,
-              class: "flex items-center px-5 py-2 text-sm text-gray-700 capitalize transition-colors duration-200 bg-white border rounded-md gap-x-2 hover:bg-gray-100 dark:bg-gray-900 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800") do %>
+              class: "flex items-center px-5 py-2 text-sm text-slate-700 capitalize transition-colors duration-200 bg-white border rounded-md gap-x-2 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-800") do %>
     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
     </svg>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -8,8 +8,7 @@
     remote:        data-remote
 -%>
 <% if page.current? %>
-  <%= link_to(page, "#", remote: remote, rel: page.rel,
-              class: "px-2 py-1 text-sm text-blue-500 rounded-md dark:bg-slate-800 bg-blue-100/60") %>
+  <span aria-current="page" class="px-2 py-1 text-sm text-blue-500 rounded-md dark:bg-slate-800 bg-blue-100/60"><%= page %></span>
 <% else %>
   <%= link_to(page, url, remote: remote, rel: page.rel,
               class: "px-2 py-1 text-sm text-slate-500 rounded-md dark:hover:bg-slate-800 dark:text-slate-300 hover:bg-slate-100") %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -9,8 +9,8 @@
 -%>
 <% if page.current? %>
   <%= link_to(page, "#", remote: remote, rel: page.rel,
-              class: "px-2 py-1 text-sm text-blue-500 rounded-md dark:bg-gray-800 bg-blue-100/60") %>
+              class: "px-2 py-1 text-sm text-blue-500 rounded-md dark:bg-slate-800 bg-blue-100/60") %>
 <% else %>
   <%= link_to(page, url, remote: remote, rel: page.rel,
-              class: "px-2 py-1 text-sm text-gray-500 rounded-md dark:hover:bg-gray-800 dark:text-gray-300 hover:bg-gray-100") %>
+              class: "px-2 py-1 text-sm text-slate-500 rounded-md dark:hover:bg-slate-800 dark:text-slate-300 hover:bg-slate-100") %>
 <% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -7,16 +7,16 @@
     remote:        data-remote
 -%>
 <% if current_page.first? %>
-  <%= link_to("#",
-              class: "flex items-center px-5 py-2 text-sm text-slate-700 capitalize transition-colors duration-200 bg-white border rounded-md gap-x-2 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-800") do %>
-    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+  <span aria-disabled="true" class="flex items-center px-5 py-2 text-sm text-slate-400 capitalize bg-white border rounded-md gap-x-2 dark:bg-slate-900 dark:text-slate-600 dark:border-slate-700 cursor-not-allowed">
+    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
       <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/>
     </svg>
-  <% end %>
+    <span class="sr-only">前のページ（無効）</span>
+  </span>
 <% else %>
-  <%= link_to(url, rel: "prev", remote: remote,
+  <%= link_to(url, rel: "prev", remote: remote, aria: { label: "前のページ" },
               class: "flex items-center px-5 py-2 text-sm text-slate-700 capitalize transition-colors duration-200 bg-white border rounded-md gap-x-2 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-800") do %>
-    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
       <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/>
     </svg>
   <% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -8,14 +8,14 @@
 -%>
 <% if current_page.first? %>
   <%= link_to("#",
-              class: "flex items-center px-5 py-2 text-sm text-gray-700 capitalize transition-colors duration-200 bg-white border rounded-md gap-x-2 hover:bg-gray-100 dark:bg-gray-900 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800") do %>
+              class: "flex items-center px-5 py-2 text-sm text-slate-700 capitalize transition-colors duration-200 bg-white border rounded-md gap-x-2 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-800") do %>
     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/>
     </svg>
   <% end %>
 <% else %>
   <%= link_to(url, rel: "prev", remote: remote,
-              class: "flex items-center px-5 py-2 text-sm text-gray-700 capitalize transition-colors duration-200 bg-white border rounded-md gap-x-2 hover:bg-gray-100 dark:bg-gray-900 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800") do %>
+              class: "flex items-center px-5 py-2 text-sm text-slate-700 capitalize transition-colors duration-200 bg-white border rounded-md gap-x-2 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-200 dark:border-slate-700 dark:hover:bg-slate-800") do %>
     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
       <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd"/>
     </svg>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,10 +1,10 @@
 <div class="flex flex-wrap items-center justify-center gap-4 mt-6 px-6 py-8 mx-auto lg:gap-6 lg:mt-0">
   <%= link_to("当サイトについて", about_path,
-              class: "text-sm text-slate-600 transition-colors duration-300 dark:text-gray-200 hover:text-blue-500 dark:hover:text-blue-400") %>
+              class: "text-sm text-slate-600 transition-colors duration-300 dark:text-slate-200 hover:text-blue-500 dark:hover:text-blue-400") %>
 
   <%= link_to("利用規約", terms_path,
-              class: "text-sm text-slate-600 transition-colors duration-300 dark:text-gray-200 hover:text-blue-500 dark:hover:text-blue-400") %>
+              class: "text-sm text-slate-600 transition-colors duration-300 dark:text-slate-200 hover:text-blue-500 dark:hover:text-blue-400") %>
 
   <%= link_to("お問い合わせ", "https://docs.google.com/forms/d/e/1FAIpQLSdP_gKGA2qcxRdN1HpjHBZUQqo7IkmojliFhmrrfECLm_AMaQ/viewform?usp=dialog",
-              class: "text-sm text-slate-600 transition-colors duration-300 dark:text-gray-200 hover:text-blue-500 dark:hover:text-blue-400") %>
+              class: "text-sm text-slate-600 transition-colors duration-300 dark:text-slate-200 hover:text-blue-500 dark:hover:text-blue-400") %>
 </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,10 +1,10 @@
 <div class="flex flex-wrap items-center justify-center gap-4 mt-6 px-6 py-8 mx-auto lg:gap-6 lg:mt-0">
   <%= link_to("当サイトについて", about_path,
-              class: "text-sm text-gray-600 transition-colors duration-300 dark:text-gray-200 hover:text-blue-500 dark:hover:text-blue-400") %>
+              class: "text-sm text-slate-600 transition-colors duration-300 dark:text-gray-200 hover:text-blue-500 dark:hover:text-blue-400") %>
 
   <%= link_to("利用規約", terms_path,
-              class: "text-sm text-gray-600 transition-colors duration-300 dark:text-gray-200 hover:text-blue-500 dark:hover:text-blue-400") %>
+              class: "text-sm text-slate-600 transition-colors duration-300 dark:text-gray-200 hover:text-blue-500 dark:hover:text-blue-400") %>
 
   <%= link_to("お問い合わせ", "https://docs.google.com/forms/d/e/1FAIpQLSdP_gKGA2qcxRdN1HpjHBZUQqo7IkmojliFhmrrfECLm_AMaQ/viewform?usp=dialog",
-              class: "text-sm text-gray-600 transition-colors duration-300 dark:text-gray-200 hover:text-blue-500 dark:hover:text-blue-400") %>
+              class: "text-sm text-slate-600 transition-colors duration-300 dark:text-gray-200 hover:text-blue-500 dark:hover:text-blue-400") %>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -8,7 +8,7 @@
         <div class="flex lg:hidden">
           <button data-action="click->navbar#toggle"
                   type="button"
-                  class="text-slate-500 dark:text-slate-200 hover:text-slate-600 dark:hover:text-slate-400 focus:outline-hidden focus:text-slate-600 dark:focus:text-slate-400"
+                  class="text-slate-500 dark:text-slate-200 hover:text-slate-600 dark:hover:text-slate-400 focus:outline-hidden focus:ring-3 focus:ring-blue-300/40 rounded"
                   aria-label="Toggle menu">
             <svg data-navbar-target="closedIcon"
                  xmlns="http://www.w3.org/2000/svg"

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,14 +1,14 @@
-<nav data-controller="navbar" class="relative bg-white shadow-sm dark:bg-gray-800">
+<nav data-controller="navbar" class="relative bg-white shadow-sm dark:bg-slate-800">
   <div class="container px-6 py-4 mx-auto">
     <div class="lg:flex lg:items-center lg:justify-between">
       <div class="flex items-center justify-between">
-        <%= link_to("Chalice-rium", root_path, class: "text-xl font-medium text-gray-600 dark:text-gray-200") %>
+        <%= link_to("Chalice-rium", root_path, class: "text-xl font-medium text-slate-600 dark:text-slate-200") %>
 
         <%# Mobile menu button %>
         <div class="flex lg:hidden">
           <button data-action="click->navbar#toggle"
                   type="button"
-                  class="text-gray-500 dark:text-gray-200 hover:text-gray-600 dark:hover:text-gray-400 focus:outline-hidden focus:text-gray-600 dark:focus:text-gray-400"
+                  class="text-slate-500 dark:text-slate-200 hover:text-slate-600 dark:hover:text-slate-400 focus:outline-hidden focus:text-slate-600 dark:focus:text-slate-400"
                   aria-label="Toggle menu">
             <svg data-navbar-target="closedIcon"
                  xmlns="http://www.w3.org/2000/svg"
@@ -40,19 +40,19 @@
 
       <div data-navbar-target="menu"
            data-navbar-is-open-value="false"
-           class="opacity-0 -x-translate-x-full absolute inset-x-0 z-20 w-full px-6 py-4 transition-all duration-300 ease-in-out bg-white dark:bg-gray-800 lg:mt-0 lg:p-0 lg:top-0 lg:relative lg:bg-transparent lg:w-auto lg:opacity-100 lg:translate-x-0 lg:flex lg:items-center">
+           class="opacity-0 -x-translate-x-full absolute inset-x-0 z-20 w-full px-6 py-4 transition-all duration-300 ease-in-out bg-white dark:bg-slate-800 lg:mt-0 lg:p-0 lg:top-0 lg:relative lg:bg-transparent lg:w-auto lg:opacity-100 lg:translate-x-0 lg:flex lg:items-center">
         <div class="flex flex-col -mx-6 lg:flex-row lg:items-center lg:mx-8">
           <% if user_signed_in? %>
             <%= link_to(t("label.user.profile"), current_user,
-                        class: "px-3 py-2 mx-3 mt-2 text-gray-700 transition-colors duration-300 transform rounded-md lg:mt-0 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700") %>
+                        class: "px-3 py-2 mx-3 mt-2 text-slate-700 transition-colors duration-300 transform rounded-md lg:mt-0 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700") %>
             <%= link_to(t("label.user.logout"), destroy_user_session_path,
-                        class: "px-3 py-2 mx-3 mt-2 text-gray-700 transition-colors duration-300 transform rounded-md lg:mt-0 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700",
+                        class: "px-3 py-2 mx-3 mt-2 text-slate-700 transition-colors duration-300 transform rounded-md lg:mt-0 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700",
                         data: { "turbo-method": :delete }) %>
           <% else %>
             <%= link_to(t("label.user.login"), new_user_session_path,
-                        class: "px-3 py-2 mx-3 mt-2 text-gray-700 transition-colors duration-300 transform rounded-md lg:mt-0 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700") %>
+                        class: "px-3 py-2 mx-3 mt-2 text-slate-700 transition-colors duration-300 transform rounded-md lg:mt-0 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700") %>
             <%= link_to(t("label.user.signup"), new_user_registration_path,
-                        class: "px-3 py-2 mx-3 mt-2 text-gray-700 transition-colors duration-300 transform rounded-md lg:mt-0 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700") %>
+                        class: "px-3 py-2 mx-3 mt-2 text-slate-700 transition-colors duration-300 transform rounded-md lg:mt-0 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700") %>
           <% end %>
         </div>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
+  <body class="min-h-screen flex flex-col bg-slate-50 dark:bg-slate-900">
     <header>
       <%= render "layouts/header" %>
     </header>
@@ -51,7 +51,7 @@
     <main class="container mx-auto mt-28 mb-28 px-5 flex">
       <%= yield %>
     </main>
-    <footer class="mt-auto bg-white dark:bg-gray-900">
+    <footer class="mt-auto bg-white dark:bg-slate-900">
       <%= render "layouts/footer" %>
     </footer>
     <div data-controller="toast"

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -7,13 +7,13 @@
       body {
         margin: 0;
         padding: 0;
-        background-color: #f3f4f6;
-        color: #1f2937;
+        background-color: #f1f5f9;   /* slate-100 */
+        color: #1e293b;               /* slate-800 */
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       }
 
       a {
-        color: #2563eb;
+        color: #2563eb;               /* blue-600 (accent) */
       }
 
       .email-shell {
@@ -33,12 +33,12 @@
         font-weight: 700;
         letter-spacing: 0.12em;
         text-transform: uppercase;
-        color: #6b7280;
+        color: #64748b;               /* slate-500 */
       }
 
       .email-card {
         background-color: #ffffff;
-        border: 1px solid #e5e7eb;
+        border: 1px solid #e2e8f0;   /* slate-200 */
         border-radius: 16px;
         padding: 32px;
         box-sizing: border-box;
@@ -49,21 +49,21 @@
         font-size: 28px;
         line-height: 1.3;
         font-weight: 700;
-        color: #111827;
+        color: #0f172a;               /* slate-900 */
       }
 
       .email-text {
         margin: 0 0 16px;
         font-size: 16px;
         line-height: 1.75;
-        color: #374151;
+        color: #334155;               /* slate-700 */
       }
 
       .email-muted {
         margin: 0;
         font-size: 14px;
         line-height: 1.7;
-        color: #6b7280;
+        color: #64748b;               /* slate-500 */
       }
 
       .email-actions {
@@ -74,7 +74,7 @@
         display: inline-block;
         padding: 12px 20px;
         border-radius: 10px;
-        background-color: #2563eb;
+        background-color: #1e293b;   /* slate-800 = ink */
         color: #ffffff !important;
         font-size: 14px;
         font-weight: 700;
@@ -85,7 +85,7 @@
       .email-footer {
         margin-top: 24px;
         padding-top: 24px;
-        border-top: 1px solid #e5e7eb;
+        border-top: 1px solid #e2e8f0;  /* slate-200 */
       }
 
       @media screen and (max-width: 640px) {

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -1,16 +1,16 @@
 <% provide(:title, "当サイトについて") %>
-<div class="w-full max-w-7xl p-6 m-auto mx-auto bg-white rounded-lg shadow-md dark:bg-gray-800">
-  <h1 class="text-3xl font-bold mb-6 text-gray-600 dark:text-gray-200">Chalice-rium</h1>
+<div class="w-full max-w-7xl p-6 m-auto mx-auto bg-white rounded-lg shadow-md dark:bg-slate-800">
+  <h1 class="text-3xl font-bold mb-6 text-slate-800 dark:text-slate-200">Chalice-rium</h1>
 
   <div class="mb-8">
-    <p class="text-gray-600 dark:text-gray-200">
+    <p class="text-slate-600 dark:text-slate-200">
       Chalice-rium は、Bloodborne プレイヤーのために作られた聖杯ダンジョンの情報を記録・共有するためのプラットフォームです。
     </p>
   </div>
 
   <section class="mb-8">
-    <h2 class="text-xl font-semibold mb-4 text-gray-600 dark:text-gray-200">主な機能</h2>
-    <ul class="list-disc pl-5 space-y-2 text-gray-600 dark:text-gray-200">
+    <h2 class="text-xl font-semibold mb-4 text-slate-800 dark:text-slate-200">主な機能</h2>
+    <ul class="list-disc pl-5 space-y-2 text-slate-600 dark:text-slate-200">
       <li>聖杯ダンジョンの情報管理（聖杯文字、深度、区画など）</li>
       <li>層ごとのボス情報の記録</li>
       <li>詳細な検索とフィルタリング（開発中）</li>
@@ -18,19 +18,19 @@
   </section>
 
   <section class="mb-8">
-    <h2 class="text-xl font-semibold mb-4 text-gray-600 dark:text-gray-200">推奨環境</h2>
-    <ul class="list-disc pl-5 space-y-2 text-gray-600 dark:text-gray-200">
+    <h2 class="text-xl font-semibold mb-4 text-slate-800 dark:text-slate-200">推奨環境</h2>
+    <ul class="list-disc pl-5 space-y-2 text-slate-600 dark:text-slate-200">
       <li>Google Chrome（最新版）</li>
       <li>Mozilla Firefox（最新版）</li>
     </ul>
-    <p class="mt-4 text-gray-600 dark:text-gray-200">
+    <p class="mt-4 text-slate-600 dark:text-slate-200">
       より良い利用環境のため、ブラウザは常に最新版にアップデートしていただくことを推奨してます。
     </p>
   </section>
 
   <section class="mb-8">
-    <h2 class="text-xl font-semibold mb-4 text-gray-600 dark:text-gray-200">ご利用に際して</h2>
-    <p class="text-gray-600 dark:text-gray-200">
+    <h2 class="text-xl font-semibold mb-4 text-slate-800 dark:text-slate-200">ご利用に際して</h2>
+    <p class="text-slate-600 dark:text-slate-200">
       本サービスは非公式のファンメイドコンテンツです。FROM SOFTWARE および Sony Interactive Entertainment とは一切関係ありません。
     </p>
   </section>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,51 +1,51 @@
 <% provide(:title, "利用規約") %>
-<div class="w-full max-w-7xl p-6 m-auto mx-auto bg-white rounded-lg shadow-md dark:bg-gray-800">
-    <h1 class="text-2xl font-bold mb-6 text-gray-600 dark:text-gray-200">利用規約</h1>
+<div class="w-full max-w-7xl p-6 m-auto mx-auto bg-white rounded-lg shadow-md dark:bg-slate-800">
+    <h1 class="text-2xl font-bold mb-6 text-slate-800 dark:text-slate-200">利用規約</h1>
 
     <section class="mb-8">
-      <h2 class="text-xl font-semibold mb-4 text-gray-600 dark:text-gray-200">1. はじめに</h2>
-      <p class="text-gray-600 dark:text-gray-200 mb-4">
+      <h2 class="text-xl font-semibold mb-4 text-slate-800 dark:text-slate-200">1. はじめに</h2>
+      <p class="text-slate-600 dark:text-slate-200 mb-4">
         本利用規約（以下「本規約」）は、Chalice-rium（以下「本サービス」）の利用条件を定めるものです。ユーザーの皆様には、本規約に同意いただいた上で本サービスをご利用いただきます。
       </p>
     </section>
 
     <section class="mb-8">
-      <h2 class="text-xl font-semibold mb-4 text-gray-600 dark:text-gray-200">2. サービスの概要</h2>
-      <p class="text-gray-600 dark:text-gray-200 mb-4">
+      <h2 class="text-xl font-semibold mb-4 text-slate-800 dark:text-slate-200">2. サービスの概要</h2>
+      <p class="text-slate-600 dark:text-slate-200 mb-4">
         本サービスは、Bloodborne（以下「対象ゲーム」）における聖杯ダンジョンの管理・共有を目的としたプラットフォームです。
       </p>
     </section>
 
     <section class="mb-8">
-      <h2 class="text-xl font-semibold mb-4 text-gray-600 dark:text-gray-200">3. アカウント管理</h2>
+      <h2 class="text-xl font-semibold mb-4 text-slate-800 dark:text-slate-200">3. アカウント管理</h2>
 
-      <h3 class="text-lg font-semibold mb-3 text-gray-600 dark:text-gray-200">3.1 登録情報</h3>
-      <ul class="list-disc pl-6 mb-4 text-gray-600 dark:text-gray-200">
+      <h3 class="text-lg font-semibold mb-3 text-slate-800 dark:text-slate-200">3.1 登録情報</h3>
+      <ul class="list-disc pl-6 mb-4 text-slate-600 dark:text-slate-200">
         <li class="mb-2">ユーザーは、登録時に正確な情報を提供する必要があります</li>
         <li class="mb-2">登録には有効なメールアドレスが必要です</li>
         <li class="mb-2">パスワードの管理はユーザーの責任において行っていただきます</li>
         <li class="mb-2">アカウント情報の漏洩や不正利用が確認された場合は、直ちに運営者に報告してください</li>
       </ul>
 
-      <h3 class="text-lg font-semibold mb-3 text-gray-600 dark:text-gray-200">3.2 アカウントの削除</h3>
-      <ul class="list-disc pl-6 mb-4 text-gray-600 dark:text-gray-200">
+      <h3 class="text-lg font-semibold mb-3 text-slate-800 dark:text-slate-200">3.2 アカウントの削除</h3>
+      <ul class="list-disc pl-6 mb-4 text-slate-600 dark:text-slate-200">
         <li class="mb-2">ユーザーは任意でアカウントを削除することができます</li>
         <li class="mb-2">本規約に違反した場合、事前の通知なくアカウントを削除する場合があります</li>
       </ul>
     </section>
 
     <section class="mb-8">
-      <h2 class="text-xl font-semibold mb-4 text-gray-600 dark:text-gray-200">4. 禁止事項</h2>
+      <h2 class="text-xl font-semibold mb-4 text-slate-800 dark:text-slate-200">4. 禁止事項</h2>
 
-      <h3 class="text-lg font-semibold mb-3 text-gray-600 dark:text-gray-200">4.1 聖杯ダンジョンに関する禁止事項</h3>
-      <ul class="list-disc pl-6 mb-4 text-gray-600 dark:text-gray-200">
+      <h3 class="text-lg font-semibold mb-3 text-slate-800 dark:text-slate-200">4.1 聖杯ダンジョンに関する禁止事項</h3>
+      <ul class="list-disc pl-6 mb-4 text-slate-600 dark:text-slate-200">
         <li class="mb-2">自身が作成していない、または作成者から登録の同意を得ていない聖杯ダンジョンの登録</li>
         <li class="mb-2">改造ツールを使用して作成した聖杯ダンジョン（いわゆる改造聖杯）の登録</li>
         <li class="mb-2">PlayStation NetworkなどBloodborneをプレイするに必要なサービスが定める利用規約に違反する方法で作成された聖杯ダンジョンの登録</li>
       </ul>
 
-      <h3 class="text-lg font-semibold mb-3 text-gray-600 dark:text-gray-200">4.2 一般的な禁止事項</h3>
-      <ul class="list-disc pl-6 mb-4 text-gray-600 dark:text-gray-200">
+      <h3 class="text-lg font-semibold mb-3 text-slate-800 dark:text-slate-200">4.2 一般的な禁止事項</h3>
+      <ul class="list-disc pl-6 mb-4 text-slate-600 dark:text-slate-200">
         <li class="mb-2">他のユーザーへの嫌がらせや迷惑行為</li>
         <li class="mb-2">虚偽情報の投稿</li>
         <li class="mb-2">本サービスの運営を妨害する行為</li>
@@ -57,40 +57,40 @@
     </section>
 
     <section class="mb-8">
-      <h2 class="text-xl font-semibold mb-4 text-gray-600 dark:text-gray-200">5. 個人情報の取り扱い</h2>
+      <h2 class="text-xl font-semibold mb-4 text-slate-800 dark:text-slate-200">5. 個人情報の取り扱い</h2>
 
-      <h3 class="text-lg font-semibold mb-3 text-gray-600 dark:text-gray-200">5.1 収集する情報</h3>
-      <ul class="list-disc pl-6 mb-4 text-gray-600 dark:text-gray-200">
+      <h3 class="text-lg font-semibold mb-3 text-slate-800 dark:text-slate-200">5.1 収集する情報</h3>
+      <ul class="list-disc pl-6 mb-4 text-slate-600 dark:text-slate-200">
         <li class="mb-2">メールアドレス</li>
         <li class="mb-2">ユーザー名</li>
         <li class="mb-2">その他アカウント設定に必要な情報</li>
       </ul>
 
-      <h3 class="text-lg font-semibold mb-3 text-gray-600 dark:text-gray-200">5.2 個人情報の利用目的</h3>
-      <ul class="list-disc pl-6 mb-4 text-gray-600 dark:text-gray-200">
+      <h3 class="text-lg font-semibold mb-3 text-slate-800 dark:text-slate-200">5.2 個人情報の利用目的</h3>
+      <ul class="list-disc pl-6 mb-4 text-slate-600 dark:text-slate-200">
         <li class="mb-2">ユーザー認証</li>
         <li class="mb-2">サービスの提供・運営</li>
         <li class="mb-2">カスタマーサポート</li>
       </ul>
 
-      <h3 class="text-lg font-semibold mb-3 text-gray-600 dark:text-gray-200">5.3 個人情報の管理</h3>
-      <ul class="list-disc pl-6 mb-4 text-gray-600 dark:text-gray-200">
+      <h3 class="text-lg font-semibold mb-3 text-slate-800 dark:text-slate-200">5.3 個人情報の管理</h3>
+      <ul class="list-disc pl-6 mb-4 text-slate-600 dark:text-slate-200">
         <li class="mb-2">収集した個人情報は適切に管理し、無断で第三者に提供しません</li>
         <li class="mb-2">法令に基づく場合を除き、事前の同意なく個人情報を開示しません</li>
       </ul>
     </section>
 
     <section class="mb-8">
-      <h2 class="text-xl font-semibold mb-4 text-gray-600 dark:text-gray-200">6. 知的財産権</h2>
-      <ul class="list-disc pl-6 mb-4 text-gray-600 dark:text-gray-200">
+      <h2 class="text-xl font-semibold mb-4 text-slate-800 dark:text-slate-200">6. 知的財産権</h2>
+      <ul class="list-disc pl-6 mb-4 text-slate-600 dark:text-slate-200">
         <li class="mb-2">本サービスに関する知的財産権は運営者に帰属します</li>
         <li class="mb-2">ユーザーが投稿したコンテンツの権利はユーザーに帰属しますが、本サービスでの利用に必要な範囲で、運営者に利用を許諾するものとします</li>
       </ul>
     </section>
 
     <section class="mb-8">
-      <h2 class="text-xl font-semibold mb-4 text-gray-600 dark:text-gray-200">7. 免責事項</h2>
-      <ul class="list-disc pl-6 mb-4 text-gray-600 dark:text-gray-200">
+      <h2 class="text-xl font-semibold mb-4 text-slate-800 dark:text-slate-200">7. 免責事項</h2>
+      <ul class="list-disc pl-6 mb-4 text-slate-600 dark:text-slate-200">
         <li class="mb-2">本サービスの利用により生じた損害について、運営者は一切の責任を負いません</li>
         <li class="mb-2">サービスの中断、変更、終了による損害について責任を負いません</li>
         <li class="mb-2">ユーザー間のトラブルについて、運営者は一切関与しません</li>
@@ -98,28 +98,28 @@
     </section>
 
     <section class="mb-8">
-      <h2 class="text-xl font-semibold mb-4 text-gray-600 dark:text-gray-200">8. 規約の変更</h2>
-      <ul class="list-disc pl-6 mb-4 text-gray-600 dark:text-gray-200">
+      <h2 class="text-xl font-semibold mb-4 text-slate-800 dark:text-slate-200">8. 規約の変更</h2>
+      <ul class="list-disc pl-6 mb-4 text-slate-600 dark:text-slate-200">
         <li class="mb-2">運営者は、必要に応じて本規約を変更することができます</li>
         <li class="mb-2">変更後の規約は、本サービス上での告知後に効力を生じるものとします</li>
       </ul>
     </section>
 
     <section class="mb-8">
-      <h2 class="text-xl font-semibold mb-4 text-gray-600 dark:text-gray-200">9. 準拠法</h2>
-      <ul class="list-disc pl-6 mb-4 text-gray-600 dark:text-gray-200">
+      <h2 class="text-xl font-semibold mb-4 text-slate-800 dark:text-slate-200">9. 準拠法</h2>
+      <ul class="list-disc pl-6 mb-4 text-slate-600 dark:text-slate-200">
         <li class="mb-2">本規約の解釈にあたっては、日本法を準拠法とします</li>
       </ul>
     </section>
 
     <section class="mb-8">
-      <h2 class="text-xl font-semibold mb-4 text-gray-600 dark:text-gray-200">10. お問い合わせ</h2>
-      <p class="text-gray-600 dark:text-gray-200 mb-4">
+      <h2 class="text-xl font-semibold mb-4 text-slate-800 dark:text-slate-200">10. お問い合わせ</h2>
+      <p class="text-slate-600 dark:text-slate-200 mb-4">
         本規約に関するお問い合わせは、本サービスのお問い合わせフォームよりご連絡ください。
       </p>
     </section>
 
-    <div class="mt-8 text-right text-gray-600 dark:text-gray-200">
+    <div class="mt-8 text-right text-slate-600 dark:text-slate-200">
       <p>制定日：2025年1月18日</p>
     </div>
   </div>

--- a/app/views/users/_social.html.erb
+++ b/app/views/users/_social.html.erb
@@ -1,6 +1,6 @@
 <% if user.twitter_link.present? %>
   <div class="mt-4">
-    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="inline stroke-gray-600 dark:stroke-gray-200 icon icon-tabler icons-tabler-outline icon-tabler-brand-x">
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="inline stroke-slate-600 dark:stroke-slate-200 icon icon-tabler icons-tabler-outline icon-tabler-brand-x">
       <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
       <path d="M4 4l11.733 16h4.267l-11.733 -16z"/>
       <path d="M4 20l6.768 -6.768m2.46 -2.46l6.772 -6.772"/>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, t("label.user.profile_edit")) %>
 <%= render Ui::CardComponent.new(size: :sm) do %>
-  <h3 class="mt-3 text-xl font-medium text-center text-gray-600 dark:text-gray-200">
+  <h3 class="mt-3 text-xl font-medium text-center text-slate-800 dark:text-slate-200">
     <%= t("label.user.profile_edit") %>
   </h3>
 
@@ -31,16 +31,16 @@
     <div class="mt-4">
       <%= f.label :twitter_link, class: "sr-only" %>
       <div class="flex items-center">
-        <p class="px-3 py-2 text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 border dark:border-gray-800 border-r-0 rounded-l-lg">
+        <p class="px-3 py-2 text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-800 border dark:border-slate-800 border-r-0 rounded-l-lg">
           x.com/
         </p>
         <%= f.text_field(:twitter_link,
-                         class: "block w-full px-4 py-2 text-gray-700 bg-white border rounded-l-none rounded-lg dark:bg-gray-800 dark:text-gray-300 dark:border-gray-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3") %>
+                         class: "block w-full px-4 py-2 text-slate-700 bg-white border border-slate-300 rounded-l-none rounded-lg dark:bg-slate-800 dark:text-slate-300 dark:border-slate-600 focus:border-blue-400 dark:focus:border-blue-300 focus:ring-blue-300/40 focus:outline-hidden focus:ring-3") %>
       </div>
     </div>
 
     <div class="mt-6">
-      <%= render Ui::ButtonComponent.new(variant: :secondary, type: :submit, full_width: true) do %>
+      <%= render Ui::ButtonComponent.new(variant: :primary, type: :submit, full_width: true) do %>
         <%= t("label.general.update") %>
       <% end %>
     </div>
@@ -52,11 +52,17 @@
     <% end %>
   </div>
 
-  <hr class="mt-4 border-b dark:border-gray-600">
-
   <div class="mt-4 flex justify-center">
+    <%= render Ui::ButtonComponent.new(variant: :outline, href: user_path(@user), full_width: true) do %>
+      戻る
+    <% end %>
+  </div>
+
+  <%# Danger Zone %>
+  <div class="mt-6 border border-red-200 dark:border-red-900 rounded-lg p-4">
+    <h4 class="text-sm font-semibold text-red-700 dark:text-red-400 mb-3">Danger Zone</h4>
     <%= render Ui::ButtonComponent.new(
-      variant: :primary,
+      variant: :danger,
       href: user_path(@user),
       full_width: true,
       data: { "turbo-method": :delete, turbo_confirm: t("label.general.sure") }

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,13 +6,13 @@
   <div class="flex flex-col lg:flex-row lg:gap-4">
     <%# User Profile %>
     <div class="mb-4 w-full lg:w-80 md:flex-none">
-      <h3 class="text-2xl font-bold text-gray-600 dark:text-gray-200">
+      <h3 class="text-2xl font-bold text-slate-800 dark:text-slate-200">
         <%= @user.display_name %>
       </h3>
-      <p class="text-gray-600 dark:text-gray-200"><%= @user.username %></p>
+      <p class="text-slate-600 dark:text-slate-200"><%= @user.username %></p>
       <% if @user.bio.present? %>
-        <div class="mt-4 p-3 bg-gray-50 rounded-lg dark:bg-gray-700">
-          <p class="text-sm text-gray-600 dark:text-gray-300 whitespace-pre-wrap leading-relaxed"><%= @user.bio %></p>
+        <div class="mt-4 p-3 bg-slate-50 rounded-lg dark:bg-slate-700">
+          <p class="text-sm text-slate-600 dark:text-slate-300 whitespace-pre-wrap leading-relaxed"><%= @user.bio %></p>
         </div>
       <% end %>
 

--- a/test/components/form/checkbox_component_test.rb
+++ b/test/components/form/checkbox_component_test.rb
@@ -70,7 +70,7 @@ module Form
 
         assert_includes rendered_content, "size-4"
         assert_includes rendered_content, "rounded-sm"
-        assert_includes rendered_content, "dark:bg-gray-800"
+        assert_includes rendered_content, "dark:bg-slate-800"
       end
     end
 

--- a/test/components/form/collection_checkboxes_component_test.rb
+++ b/test/components/form/collection_checkboxes_component_test.rb
@@ -57,7 +57,7 @@ module Form
           label: "Rites", disabled: true
         ))
 
-        assert_includes rendered_content, "text-gray-500"
+        assert_includes rendered_content, "text-slate-500"
       end
     end
 

--- a/test/components/form/field_component_test.rb
+++ b/test/components/form/field_component_test.rb
@@ -89,7 +89,7 @@ module Form
 
         assert_includes rendered_content, "block w-full"
         assert_includes rendered_content, "rounded-lg"
-        assert_includes rendered_content, "dark:bg-gray-800"
+        assert_includes rendered_content, "dark:bg-slate-800"
       end
     end
 
@@ -153,7 +153,7 @@ module Form
           hint: "※6文字以上"
         ))
 
-        assert_selector "p.text-gray-600", text: "※6文字以上"
+        assert_selector "p.text-slate-600", text: "※6文字以上"
       end
     end
 
@@ -201,7 +201,7 @@ module Form
       with_controller_class(UsersController) do
         render_inline(FieldComponent.new(form: form_for(@user), attribute: :username))
 
-        assert_no_selector "p.text-gray-600"
+        assert_no_selector "p.text-slate-600"
       end
     end
 

--- a/test/components/form/layer_field_component_test.rb
+++ b/test/components/form/layer_field_component_test.rb
@@ -46,7 +46,7 @@ module Form
         render_inline(LayerFieldComponent.new(form: layer_form_for(layer)))
 
         assert_includes rendered_content, "rounded-lg"
-        assert_includes rendered_content, "dark:bg-gray-800"
+        assert_includes rendered_content, "dark:bg-slate-800"
       end
     end
 

--- a/test/components/form/read_only_field_component_test.rb
+++ b/test/components/form/read_only_field_component_test.rb
@@ -47,7 +47,7 @@ module Form
         ))
 
         assert_includes rendered_content, "bg-slate-100"
-        assert_includes rendered_content, "text-slate-500"
+        assert_includes rendered_content, "text-slate-600"
         assert_includes rendered_content, "dark:bg-slate-700"
       end
     end

--- a/test/components/form/read_only_field_component_test.rb
+++ b/test/components/form/read_only_field_component_test.rb
@@ -46,9 +46,9 @@ module Form
           form: form_for(@user), attribute: :username, value: @user.username
         ))
 
-        assert_includes rendered_content, "bg-gray-100"
-        assert_includes rendered_content, "text-gray-500"
-        assert_includes rendered_content, "dark:bg-gray-700"
+        assert_includes rendered_content, "bg-slate-100"
+        assert_includes rendered_content, "text-slate-500"
+        assert_includes rendered_content, "dark:bg-slate-700"
       end
     end
 

--- a/test/components/form/select_component_test.rb
+++ b/test/components/form/select_component_test.rb
@@ -55,8 +55,8 @@ module Form
       ))
 
       assert_includes rendered_content, "rounded-lg"
-      assert_includes rendered_content, "dark:bg-gray-800"
-      assert_includes rendered_content, "border-gray-300"
+      assert_includes rendered_content, "dark:bg-slate-800"
+      assert_includes rendered_content, "border-slate-300"
     end
 
     test "applies wrapper_class" do

--- a/test/components/ui/badge_component_test.rb
+++ b/test/components/ui/badge_component_test.rb
@@ -7,7 +7,7 @@ module Ui
     test "renders default badge" do
       render_inline(BadgeComponent.new) { "Default" }
 
-      assert_selector "span.bg-gray-100.text-gray-700", text: "Default"
+      assert_selector "span.bg-slate-100.text-slate-700", text: "Default"
       assert_selector "span.rounded-full"
     end
 
@@ -26,7 +26,7 @@ module Ui
     test "renders warning badge" do
       render_inline(BadgeComponent.new(variant: :warning)) { "Pending" }
 
-      assert_selector "span.bg-yellow-100.text-yellow-700", text: "Pending"
+      assert_selector "span.bg-amber-100.text-amber-700", text: "Pending"
     end
 
     test "applies custom HTML options" do
@@ -46,8 +46,8 @@ module Ui
     test "includes dark mode classes for default variant" do
       render_inline(BadgeComponent.new) { "Dark" }
 
-      assert_includes rendered_content, "dark:bg-gray-700"
-      assert_includes rendered_content, "dark:text-gray-200"
+      assert_includes rendered_content, "dark:bg-slate-700"
+      assert_includes rendered_content, "dark:text-slate-200"
     end
   end
 end

--- a/test/components/ui/button_component_test.rb
+++ b/test/components/ui/button_component_test.rb
@@ -7,7 +7,7 @@ module Ui
     test "renders primary button by default" do
       render_inline(ButtonComponent.new) { "Click me" }
 
-      assert_selector "button.bg-gray-800", text: "Click me"
+      assert_selector "button.bg-slate-800", text: "Click me"
       assert_selector "button[type='button']"
     end
 
@@ -26,7 +26,7 @@ module Ui
     test "renders outline button variant" do
       render_inline(ButtonComponent.new(variant: :outline)) { "Cancel" }
 
-      assert_selector "button.bg-gray-100", text: "Cancel"
+      assert_selector "button.bg-slate-100", text: "Cancel"
     end
 
     test "renders full width button" do

--- a/test/components/ui/card_component_test.rb
+++ b/test/components/ui/card_component_test.rb
@@ -59,7 +59,7 @@ module Ui
     test "includes dark mode classes" do
       render_inline(CardComponent.new) { "Dark mode" }
 
-      assert_includes rendered_content, "dark:bg-gray-800"
+      assert_includes rendered_content, "dark:bg-slate-800"
     end
 
     test "applies custom HTML options" do

--- a/test/components/ui/description_item_component_test.rb
+++ b/test/components/ui/description_item_component_test.rb
@@ -16,14 +16,14 @@ module Ui
 
       assert_includes rendered_content, "text-sm"
       assert_includes rendered_content, "font-medium"
-      assert_includes rendered_content, "text-gray-500"
+      assert_includes rendered_content, "text-slate-500"
     end
 
     def test_includes_value_styling
       render_inline(DescriptionItemComponent.new(label: "Area", value: "Pthumeru"))
 
       assert_includes rendered_content, "text-lg"
-      assert_includes rendered_content, "text-gray-700"
+      assert_includes rendered_content, "text-slate-700"
     end
 
     def test_renders_numeric_value


### PR DESCRIPTION
## 概要

Tailwind CSS の中立色を `gray-*` → `slate-*` に統一し、デザインシステム棚卸しで発見した 8 件の不統一（#1〜#8）を解消する UI リデザイン実装です。あわせて dual-review (Claude + Codex) で検出したアクセシビリティ問題を修正しています。

## 変更内容

### Phase 0 — デザイントークン
- `app/assets/tailwind/application.css` に Tailwind v4 `@theme` セマンティックトークンを追加
- border 既定色を `--color-slate-200` へ統一

### Phase 1〜2 — コンポーネント
- 全 ViewComponent の `gray-*` → `slate-*` 1:1 置換
- `ButtonComponent`: primary=slate-800, secondary=blue-600, danger=red-600, outline=slate-100
- focus ring を `ring-blue-300/40` に全要素統一（Audit #5）
- `BadgeComponent`: warning を amber へ統一
- `FieldComponent`: `border-slate-300` を明示し Select と外観を揃える

### Phase 3 — ビュー
- レイアウト・ヘッダー・フッター gray→slate
- ダンジョン一覧: 検索/リセットを `Ui::ButtonComponent` へ（Audit #2）、テーブル `rounded-lg` 統一（Audit #6）、glyph に `font-mono text-blue-600`
- ダンジョン詳細: glyph 見出し `font-mono`、削除を `variant: :danger`（Audit #4）
- Devise ビュー: `confirmations/new` を Card+Field+Button で再実装（Audit #1）、パスワードフォームを `FieldComponent` に集約（Audit #3）、`shared/_links` を統一スタイルへ
- ユーザー設定: Danger Zone 追加、退会を `variant: :danger`（Audit #4）
- メールレイアウト: 生 hex を slate トークン同値へ（Audit #7）
- 見出し色を `text-slate-800` に統一（Audit #8）

### アクセシビリティ修正（dual-review 指摘）
- Flash 閉じるボタン: `focus:ring` + `aria-label="閉じる"` + SVG `aria-hidden`
- ナビ hamburger: `focus:ring-3 focus:ring-blue-300/40` を追加
- Kaminari: prev/next を `<span aria-disabled>` / `aria-label` 付きリンクに、gap と現在ページを非リンク要素（`aria-current="page"`）へ
- `ReadOnlyFieldComponent`: `text-slate-500` → `text-slate-600`（コントラスト 4.35→6.1:1）
- `ButtonComponent`: secondary/danger hover を `blue-700`/`red-700` へ（hover 時 AA 確保）
- `FieldComponent`: hint/error に id、`aria-describedby` + `aria-invalid` 実装
- sessions/new 「新規登録」リンク: `text-blue-600`（3.52→4.77:1）

## テスト

- `bin/rails test`: 176 runs, 0 failures ✅
- `bin/rubocop`: no offenses ✅
- `bin/brakeman`: no warnings ✅
- ブラウザ目視（localhost:3000 ライトモード）: 一覧・詳細・ログイン・ダンジョン登録ページ ✅

## スコープ外

- ダークモード再設計（`dark:` 値は追随のみ）
- コンポーネント API 変更・新規コンポーネント
- 案B（Hunter's Dream / ダーク基調）

🤖 Generated with [Claude Code](https://claude.com/claude-code)