### PR TITLE
fix(ui): dark mode で primary/outline ボタンが背景と同化する問題を修正

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -32,6 +32,35 @@
   --radius-lg: 0.5rem;
 }
 
+/* button semantic colors — light (defaults) */
+:root {
+  --btn-primary:        #1e293b;   /* slate-800 : primary fill */
+  --btn-primary-text:   #ffffff;   /* primary text */
+  --btn-primary-hover:  #334155;   /* slate-700 */
+  --btn-outline:        #f1f5f9;   /* slate-100 */
+  --btn-outline-hover:  #e2e8f0;   /* slate-200 */
+}
+
+/* dark overrides (primary inverts, outline one step lighter) */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --btn-primary:        #f1f5f9;   /* slate-100 : inverted */
+    --btn-primary-text:   #0f172a;   /* slate-900 */
+    --btn-primary-hover:  #e2e8f0;   /* slate-200 */
+    --btn-outline:        #475569;   /* slate-600 */
+    --btn-outline-hover:  #64748b;   /* slate-500 */
+  }
+}
+
+/* expose button colors as utilities that follow the vars above */
+@theme inline {
+  --color-btn-primary:        var(--btn-primary);
+  --color-btn-primary-text:   var(--btn-primary-text);
+  --color-btn-primary-hover:  var(--btn-primary-hover);
+  --color-btn-outline:        var(--btn-outline);
+  --color-btn-outline-hover:  var(--btn-outline-hover);
+}
+
 /* preserve the v3 behaviour */
 @layer base {
   *, ::after, ::before, ::backdrop, ::file-selector-button {

--- a/app/components/ui/button_component.rb
+++ b/app/components/ui/button_component.rb
@@ -3,10 +3,10 @@
 module Ui
   class ButtonComponent < ApplicationComponent
     VARIANT_CLASSES = {
-      primary:   "bg-slate-800 hover:bg-slate-700 text-white focus:ring-blue-300/40",
+      primary:   "bg-btn-primary hover:bg-btn-primary-hover text-btn-primary-text focus:ring-blue-300/40",
       secondary: "bg-blue-600 hover:bg-blue-700 text-white focus:ring-blue-300/40",
       danger:    "bg-red-600 hover:bg-red-700 text-white focus:ring-blue-300/40",
-      outline:   "bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-600 focus:ring-blue-300/40"
+      outline:   "bg-btn-outline hover:bg-btn-outline-hover text-slate-600 dark:text-slate-200 focus:ring-blue-300/40"
     }.freeze
 
     SIZE_CLASSES = {

--- a/test/components/ui/button_component_test.rb
+++ b/test/components/ui/button_component_test.rb
@@ -7,7 +7,7 @@ module Ui
     test "renders primary button by default" do
       render_inline(ButtonComponent.new) { "Click me" }
 
-      assert_selector "button.bg-slate-800", text: "Click me"
+      assert_selector "button.bg-btn-primary", text: "Click me"
       assert_selector "button[type='button']"
     end
 
@@ -26,7 +26,7 @@ module Ui
     test "renders outline button variant" do
       render_inline(ButtonComponent.new(variant: :outline)) { "Cancel" }
 
-      assert_selector "button.bg-slate-100", text: "Cancel"
+      assert_selector "button.bg-btn-outline", text: "Cancel"
     end
 
     test "renders full width button" do


### PR DESCRIPTION
## 概要

dark mode で primary ボタン(`bg-slate-800`)がカード(`dark:bg-slate-800`)と完全同色になり、輪郭が消えて文字だけが浮遊する問題を修正します。実UI（プロフィール編集ページ）で「更新」「X と連携する」の2つの primary ボタンが不可視、outline(`slate-700`)も低コントラストであることを Chrome で確認していました。

根本原因は、dark mode が `@theme` デザイントークンではなく各コンポーネントの `dark:slate-*` 直書きで実装されており、primary/outline に適切な dark 値が無かったことです。

## アプローチ（Phase 1）

Tailwind v4 の `@theme inline` + 間接変数 + `@media (prefers-color-scheme: dark)` でトークンを2値化し、1つの `bg-btn-*` クラスが light/dark に自動追従する形にしました（`dark:` 変種が不要）。本PRでは **button コンポーネントのみ**をトークン参照へ移行します。

配色（塗り変更方式）:
- **primary**: dark で反転 — bg `slate-100` / text `slate-900` / hover `slate-200`
- **outline**: dark で `slate-600`（現状 slate-700 から一段明るく）
- **secondary(blue) / danger(red)**: 両モードで問題ないため据え置き

light 値は現行挙動（slate-800/700, slate-100/200）と一致させており、**light mode の見た目は不変**です。

## 変更ファイル

- `app/assets/tailwind/application.css` — `--color-btn-*` トークンを純粋追加（既存 `@theme` は無変更）
- `app/components/ui/button_component.rb` — primary / outline をトークン参照へ
- `test/components/ui/button_component_test.rb` — クラス名変更に追従

## 検証

- ✅ 全体テスト: 210 tests, 481 assertions, 0 failures, 0 errors
- ✅ RuboCop: no offenses
- ✅ Chrome 実UI（dark mode エミュレート）: primary が白ボタンとして明瞭、outline が slate-600 でカードから分離
- ✅ light mode 回帰なし（build CSS の light 値が旧 slate-800/100 と一致）

## スコープ外（Phase 2 / 別PR）

- card / form / badge / header 等の残りコンポーネントのトークン移行
- 未使用 `@theme` トークン（`--color-surface*` 等）の整理・セマンティック再定義
- `@tailwindcss/forms` の select 矢印色は SVG にビルド時焼き込みのため、dark 対応には別途 `dark:` の `background-image` 上書きが必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)
